### PR TITLE
feat: implement MCP tool endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "@modelcontextprotocol/sdk": "^1.17.5",
     "body-parser": "^2.2.0",
     "express": "^5.1.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.24.6"
   },
   "type": "module"
 }


### PR DESCRIPTION
## Summary
- add handlers for `tools/list` and `tools/call` to comply with MCP protocol
- return structured tool results and expose tool metadata
- declare `zod-to-json-schema` dependency

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c0811bc3608326844c76d758a421e7